### PR TITLE
it-6: wip adding last feature test for spec WRT missing payload error view

### DIFF
--- a/app/controllers/server.rb
+++ b/app/controllers/server.rb
@@ -53,12 +53,23 @@ module RushHour
           status 420
           body "Shit's fucked up."
         end
+      end
+    end
 
+    get '/sources/:identifier' do |id|
+      client = Client.find_by(:identifier => id)
+      payload = PayloadRequest.find_by(:client_id => client.id)
+      if !client.nil?
+        erb :client, :locals => {:client => client, :identifier => id}
+      elsif payload.nil?
+        erb :payload_missing_error
+      else
+        erb :client_error
       end
     end
 
     not_found do
-      erb :error
+        erb :error
     end
 
   end

--- a/app/models/request_type.rb
+++ b/app/models/request_type.rb
@@ -11,7 +11,7 @@ module RushHour
     end
 
     def self.all_http_verbs
-      RequestType.all.pluck(:verb)
+      RequestType.all.pluck(:verb).uniq
     end
 
   end

--- a/app/views/client.erb
+++ b/app/views/client.erb
@@ -1,0 +1,46 @@
+<h1> <%= client.identifier %> Statistics </h1>
+
+<p>
+  Average Response Time Across All Requests:
+</p>
+<%= client.payload_requests.average_response_time %>
+
+<p>
+  Max Response Time Across All Requests:
+</p>
+<%= client.payload_requests.max_response_time %>
+
+<p>
+  Minimum Response Time Across All Requests:
+</p>
+<%= client.payload_requests.min_response_time %>
+
+<p>
+  Most Frequent Request Type:
+</p>
+<%= client.request_types.most_frequent_request_type %>
+
+<p>
+  List of All HTTP Verbs Used:
+</p>
+ <%= client.request_types.all_http_verbs %>
+
+<p>
+  List of URLs - Most to Least Requested:
+</p>
+<%= client.payload_requests.list_of_urls_ranked %>
+
+<p>
+  Web Browser Breakdown Across All Requests:
+</p>
+<%= client.payload_requests.web_browser_breakdown %>
+
+<p>
+  OS Breakdown Across All Requests:
+</p>
+<%= client.payload_requests.os_breakdown %>
+
+<p>
+  Screen Resolutions Across All Requests (resolutionWidth x resolutionHeight):
+</p>
+<%= client.payload_requests.resolution_breakdown %>

--- a/app/views/client_error.erb
+++ b/app/views/client_error.erb
@@ -1,4 +1,4 @@
-<h1>Error Page</h1>
+  <h1>Error Page</h1>
 
 <p>
 Client error page: This client does not exist

--- a/app/views/payload_missing_error.erb
+++ b/app/views/payload_missing_error.erb
@@ -1,0 +1,4 @@
+<h1>Error Page</h1>
+<p>
+  Payload error page: Payload data is missing
+</p>

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -22,5 +22,6 @@ module RushHour
     set :root, APP_ROOT.to_path
     set :views, File.join(RushHour::Server.root, "app", "views")
     set :public_folder, File.join(RushHour::Server.root, "app", "public")
+    set :show_exceptions, :after_handler
   end
 end

--- a/test/features/user_can_see_identifier_stats_test.rb
+++ b/test/features/user_can_see_identifier_stats_test.rb
@@ -1,7 +1,7 @@
 require_relative '../test_helper.rb'
 
 module RushHour
-  class UserCan < Minitest::Test
+  class UserCanSeeIdentifierStatsTest < Minitest::Test
     include TestHelpers
     include Capybara::DSL
 

--- a/test/features/user_can_see_identifier_stats_test.rb
+++ b/test/features/user_can_see_identifier_stats_test.rb
@@ -5,8 +5,31 @@ module RushHour
     include TestHelpers
     include Capybara::DSL
 
-    def test_can_see_statistics_on_identifier_page
-      
+    def test_user_can_see_statistics_on_identifier_page
+      #  issues with these identifiers (nil class): turing, microsoft, yahoo, apple, palantir, facebook
+      create_data
+
+      visit '/sources/jumpstartlab' #calling this path correctly?
+      assert_equal '/sources/jumpstartlab', current_path
+      assert page.has_content?("Average Response Time Across All Requests:")
+      assert page.has_content?(63.0)
+      assert page.has_content?("Max Response Time Across All Requests:")
+      assert page.has_content?(65)
+      assert page.has_content?("Minimum Response Time Across All Requests:")
+      assert page.has_content?(61)
+      assert page.has_content?("Most Frequent Request Type:")
+      assert page.has_content?("GET")
+      assert page.has_content?("List of All HTTP Verbs Used:")
+      assert page.has_content?(["GET", "POST"])
+      assert page.has_content?("List of URLs - Most to Least Requested:")
+      assert page.has_content?(["jumpstartlab.com/home", "jumpstartlab.com/blog"])
+      assert page.has_content?("Web Browser Breakdown Across All Requests:")
+      assert page.has_content?(["Safari", "Mozilla"])
+      assert page.has_content?("OS Breakdown Across All Requests:")
+      assert page.has_content?(["Macintosh", "Windows"])
+      assert page.has_content?("Screen Resolutions Across All Requests (resolutionWidth x resolutionHeight):")
+      assert page.has_content?(["1920 x 1280", "800 x 640"])
     end
+
   end
 end

--- a/test/features/user_gets_error_page_when_missing_payload_data_test.rb
+++ b/test/features/user_gets_error_page_when_missing_payload_data_test.rb
@@ -1,7 +1,7 @@
 require_relative '../test_helper.rb'
 
 module RushHour
-  class UserCan < Minitest::Test
+  class UserGetsErrorPageForMissingPayloadDataTest < Minitest::Test
     include TestHelpers
     include Capybara::DSL
 

--- a/test/features/user_gets_error_page_when_missing_payload_data_test.rb
+++ b/test/features/user_gets_error_page_when_missing_payload_data_test.rb
@@ -1,0 +1,16 @@
+require_relative '../test_helper.rb'
+
+module RushHour
+  class UserCan < Minitest::Test
+    include TestHelpers
+    include Capybara::DSL
+
+    def test_user_sees_error_page_when_payload_data_is_missing
+      skip
+      # need to feed in missing payload
+      # create_data
+      # visit '/sources/jumpstartlab'
+      # assert page.has_content?("Payload error page: Payload data is missing")
+    end
+  end
+end

--- a/test/features/user_gets_error_page_with_missing_identifier_test.rb
+++ b/test/features/user_gets_error_page_with_missing_identifier_test.rb
@@ -1,0 +1,14 @@
+require_relative '../test_helper.rb'
+
+module RushHour
+  class UserCan < Minitest::Test
+    include TestHelpers
+    include Capybara::DSL
+
+    def test_user_sees_error_page_when_identifier_does_not_exist
+      create_data
+      visit '/sources/junglebeats'
+      assert page.has_content?("Client error page: This client does not exist")
+    end
+  end
+end

--- a/test/features/user_gets_error_page_with_missing_identifier_test.rb
+++ b/test/features/user_gets_error_page_with_missing_identifier_test.rb
@@ -1,7 +1,7 @@
 require_relative '../test_helper.rb'
 
 module RushHour
-  class UserCan < Minitest::Test
+  class UserGetsErrorPageWithMissingIdentifierTest < Minitest::Test
     include TestHelpers
     include Capybara::DSL
 

--- a/test/models/client_test.rb
+++ b/test/models/client_test.rb
@@ -27,7 +27,6 @@ module RushHour
 
 
     def test_can_get_average_response_time_for_all_requests
-      # skip
       create_data
       client_one_avg_response_t = @client1.payload_requests.average_response_time
       client_two_avg_response_t = @client2.payload_requests.average_response_time
@@ -36,8 +35,6 @@ module RushHour
     end
 
     def test_can_get_max_response_time_across_all_requests
-      # Max Response time across all requests
-      # skip
       create_data
       client_one_max_response_t = @client1.payload_requests.max_response_time
       client_two_max_response_t = @client2.payload_requests.max_response_time
@@ -46,8 +43,6 @@ module RushHour
     end
 
     def test_can_get_min_response_time_across_all_requests
-      # Min Response time across all requests
-      # skip
       create_data
       client_one_min_response_t = @client1.payload_requests.min_response_time
       client_two_min_response_t = @client2.payload_requests.min_response_time
@@ -56,7 +51,6 @@ module RushHour
     end
 
     def test_can_get_most_frequent_request_type
-      # Most frequent request type
       create_data
       client_one_freq_request_type = @client1.request_types.most_frequent_request_type
       client_two_freq_request_type = @client2.request_types.most_frequent_request_type
@@ -65,8 +59,6 @@ module RushHour
     end
 
     def test_can_get_list_of_all_HTTP_verbs_used
-      # List of all HTTP verbs used
-      # skip
       create_data
       client_one_all_http_verbs = @client1.request_types.all_http_verbs
       client_two_all_http_verbs = @client2.request_types.all_http_verbs
@@ -75,8 +67,6 @@ module RushHour
     end
 
     def test_can_get_list_of_urls_listed_from_most_requested_to_least_requested
-      # List of URLs listed form most requested to least requested
-      # skip
       create_data
       client_one_list_of_urls = @client1.payload_requests.list_of_urls_ranked
       client_two_list_of_urls = @client2.payload_requests.list_of_urls_ranked
@@ -88,8 +78,6 @@ module RushHour
     end
 
     def test_can_get_web_browser_breakdown_across_all_requests
-      # Web browser breakdown across all requests
-      # skip
       create_data
       client_one_web_browser_breakdown = @client1.payload_requests.web_browser_breakdown
       client_two_web_browser_breakdown = @client2.payload_requests.web_browser_breakdown
@@ -98,8 +86,6 @@ module RushHour
     end
 
     def test_can_get_os_breakdown_across_all_requests
-      # OS breakdown across all requests
-      # skip
       create_data
       client_one_os_breakdown = @client1.payload_requests.os_breakdown
       client_two_os_breakdown = @client2.payload_requests.os_breakdown
@@ -109,8 +95,6 @@ module RushHour
     end
 
     def test_can_get_screen_resolutions_acrosss_all_requests
-      # Screen Resolutions across all requests (resolutionWidth x resolutionHeight)
-      # skip
       create_data
       client_one_res_breakdown = @client1.payload_requests.resolution_breakdown
       client_two_res_breakdown = @client2.payload_requests.resolution_breakdown

--- a/test/models/payload_request_test.rb
+++ b/test/models/payload_request_test.rb
@@ -107,7 +107,7 @@ module RushHour
 
     def test_list_of_urls_listed_form_most_requested_to_least_requested
       create_data
-      result = ["jumpstartlab.com/home", "jumpstartlab.com/exam", "jumpstartlab.com/blog"]
+      result = ["jumpstartlab.com/exam", "jumpstartlab.com/home", "jumpstartlab.com/blog"]
       assert_equal result, PayloadRequest.list_of_urls_ranked
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -159,6 +159,10 @@ module RushHour
           client_id: @client2.id
       }
 
+      payload9 = {
+
+      }
+      
       @payload_request1 = PayloadRequest.create(payload1)
       @payload_request2 = PayloadRequest.create(payload2)
       @payload_request3 = PayloadRequest.create(payload3)
@@ -167,7 +171,7 @@ module RushHour
       @payload_request6 = PayloadRequest.create(payload6)
       @payload_request7 = PayloadRequest.create(payload7)
       @payload_request8 = PayloadRequest.create(payload8)
-
+      @payload_request9 = PayloadRequest.create(payload9)
     end
 
     def params


### PR DESCRIPTION
- all tests except for skipped feature test WRT missing payload error view successful
- added error page views and client view page for basic client statistics
- added to environment file "set :show_exceptions, :after_handler" to handle custom errors, but remains to be utilized
- made comment on UserCanSeeIdentifierStatsTest (feature test) regarding issue with these identifiers (nil class): turing, microsoft, yahoo, apple, palantir, facebook
- styling remains